### PR TITLE
Kyber ref functions located in kem.c not kyber.h

### DIFF
--- a/extensions/ext_kyber.md
+++ b/extensions/ext_kyber.md
@@ -43,7 +43,7 @@ the shared secret.
 
 The name of the algorithm shall be `Kyber`.
 
-In this definition, we use the function names from the `kyber.h` file
+In this definition, we use the function names from the `kem.c` file
 in the reference implementation of Kyber [2]:
 
  * `crypto_kem_keypair()` returns the 1088-byte public and 1248-byte private


### PR DESCRIPTION
Greetings, here's a minor correction for your most excellent specification document.